### PR TITLE
Fix #2: path always being set to $PWD.Path

### DIFF
--- a/BuildHelpers/Public/Get-BuildVariables.ps1
+++ b/BuildHelpers/Public/Get-BuildVariables.ps1
@@ -64,7 +64,7 @@ $IsGitRepo = Test-Path $( Join-Path $Path .git )
     if(-not $BuildRoot)
     {
         # Assumption: this function is defined in a file at the root of the build folder
-        $BuildRoot = $PWD.Path
+        $BuildRoot = $Path
     }
 
 # Find the git branch


### PR DESCRIPTION
If a Path was supplied via param, it was ignoring it.