### PR TITLE
Add Set-BuildVariable, resolve #10

### DIFF
--- a/BuildHelpers/BuildHelpers.psd1
+++ b/BuildHelpers/BuildHelpers.psd1
@@ -67,7 +67,7 @@ CmdletsToExport = '*'
 VariablesToExport = '*'
 
 # Aliases to export from this module
-AliasesToExport = '*'
+AliasesToExport = 'Set-BuildVariable'
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/BuildHelpers/BuildHelpers.psm1
+++ b/BuildHelpers/BuildHelpers.psm1
@@ -23,3 +23,7 @@
 
 Export-ModuleMember -Function $Public.Basename
 Export-ModuleMember -Function Get-Metadata, Update-Metadata, Export-Metadata
+
+# Set aliases (#10)
+Set-Alias -Name Set-BuildVariable -Value $PSScriptRoot\Scripts\Set-BuildVariable.ps1
+Export-ModuleMember -Alias Set-BuildVariable

--- a/BuildHelpers/Scripts/Set-BuildVariable.ps1
+++ b/BuildHelpers/Scripts/Set-BuildVariable.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+    Normalize build system and project details into variables
+
+.FUNCTIONALITY
+    CI/CD
+
+.DESCRIPTION
+    Normalize build system and project details into variables
+
+    Creates the following variables:
+        BHProjectPath      via Get-BuildVariables
+        BHBranchName       via Get-BuildVariables
+        BHCommitMessage    via Get-BuildVariables
+        BHBuildNumber      via Get-BuildVariables
+        BHProjectName      via Get-ProjectName
+        BHPSModuleManifest via Get-PSModuleManifest
+        BHPSModulePath     via Split-Path on BHPSModuleManifest
+
+.PARAMETER Path
+    Path to project root. Defaults to the current working path
+
+.PARAMETER Scope
+    Determines the scope of the variables. Valid values are "Global", "Local", or "Script", or a number
+    relative to the current scope (0 through the number of scopes, where 0 is the current scope and 1 is its
+    parent). For more information, see about_Scopes.
+
+    Defaults to the calling scope, 0 if it is dot-sourced, 1 if it is invoked normally.
+
+    The scope value Script may only be used with dot-sourced Set-BuildVariable.
+
+.NOTES
+    We assume you are in the project root, for several of the fallback options
+
+.EXAMPLE
+    Set-BuildVariable
+    Get-Variable BH* -Scope 0
+
+    # Set build variables in the current scope, read them
+
+.EXAMPLE
+    . Set-BuildVariable -Scope Script
+    Get-Variable BH* -Scope Script
+
+    # Set build variables in the script scope (mind the .), read them
+
+.LINK
+    https://github.com/RamblingCookieMonster/BuildHelpers
+
+.LINK
+    Get-BuildVariables
+
+.LINK
+    Get-ProjectName
+
+.LINK
+    about_BuildHelpers
+#>
+[cmdletbinding()]
+param(
+    $Path = $PWD.Path,
+
+    [validatescript({
+        if(-not ('Global', 'Local', 'Script', 'Current' -contains $_ -or (($_ -as [int]) -ge 0)))
+        {
+            throw "'$_' is an invalid Scope. For more information, run Get-Help Set-BuildVariable -Parameter Scope"
+        }
+        $true
+    })]
+    [string]
+    $Scope
+)
+
+if($MyInvocation.InvocationName -eq '.')
+{
+    if(-not $Scope)
+    {
+        $Scope = '0'
+    }
+}
+else
+{
+    if($Scope -eq 'Script')
+    {
+        throw 'The script scope may only be used with dot-sourced Set-BuildVariable.'
+    }
+    if(-not $Scope)
+    {
+        $Scope = '1'
+    }
+}
+
+${Build.Vars} = Get-BuildVariables -Path $Path
+${Build.ProjectName} = Get-ProjectName -Path $Path
+${Build.ManifestPath} = Get-PSModuleManifest -Path $Path
+
+Set-Variable -Scope $Scope -Name BHBuildSystem -Value ${Build.Vars}.BuildSystem
+Set-Variable -Scope $Scope -Name BHProjectPath -Value ${Build.Vars}.ProjectPath
+Set-Variable -Scope $Scope -Name BHBranchName -Value ${Build.Vars}.BranchName
+Set-Variable -Scope $Scope -Name BHCommitMessage -Value ${Build.Vars}.CommitMessage
+Set-Variable -Scope $Scope -Name BHBuildNumber -Value ${Build.Vars}.BuildNumber
+Set-Variable -Scope $Scope -Name BHProjectName -Value ${Build.ProjectName}
+Set-Variable -Scope $Scope -Name BHPSModuleManifest -Value ${Build.ManifestPath}
+Set-Variable -Scope $Scope -Name BHPSModulePath -Value $(Split-Path -Path ${Build.ManifestPath} -Parent)

--- a/BuildHelpers/en-US/about_BuildHelpers.help.txt
+++ b/BuildHelpers/en-US/about_BuildHelpers.help.txt
@@ -16,11 +16,12 @@ DETAILED DESCRIPTION
         Get-BuildVariables:   This looks at your current environment variables, and returns details on what build system you're using, the git branch, commit message, and more.
         Get-ProjectName:      This looks at the current path, and tries to guess your project / module name based on common conventions.
         Set-BuildEnvironment: This calls other BuildHelper functions, and sets environment variables that you can use in your scripts.
+        Set-BuildVariable:    This calls other BuildHelper functions, and sets PowerShell variables in the calling or specified scope.
 
     In a build environment, you might...
         * Install BuildHelper
-        * Pre-populate normalized variables by running Set-BuildEnvironment
-        * Rely on ENV:BH* variables as needed
+        * Pre-populate normalized variables by running Set-BuildEnvironment or Set-BuildVariable
+        * Rely on environment variables ENV:BH* or PowerShell variables BH* as needed
 
 LINK
     https://github.com/RamblingCookieMonster/BuildHelpers


### PR DESCRIPTION
Implemented as discussed, updated docs.
Tried to propagate coding style used in other scripts.

Not created ready to use tests.
But still tested locally.
Tested cases:

````powershell
    #defaults to -Scope 1, the caller scope
    Set-BuildVariable -Path $PSScriptRoot
    Get-Variable BH* -Scope 0

    #defaults to -Scope 0, the caller scope
    . Set-BuildVariable -Path $PSScriptRoot
    Get-Variable BH* -Scope 0

    #sets variables in the caller script scope
    . Set-BuildVariable -Path $PSScriptRoot -Scope Script
    Get-Variable BH* -Scope Script

    #error
    Set-BuildVariable -Path $PSScriptRoot -Scope Script
````
