### PR TITLE
Add handling for projects w/ source folder layout

### DIFF
--- a/BuildHelpers/Public/Get-ProjectName.ps1
+++ b/BuildHelpers/Public/Get-ProjectName.ps1
@@ -69,6 +69,15 @@ function Get-ProjectName {
         {
             $CurrentFolder
         }
+        # PSD1 in Source or Src folder
+        elseif( Get-Item "$Path\S*rc*\*.psd1", -OutVariable SourceManifests)
+        {
+            If ( $SourceManifests.Count -gt 1 )
+            {
+                Write-Warning "Found more than one project manifest in the Source folder"
+            }
+            $SourceManifests.BaseName
+        }
         else
         {
             Write-Warning "Could not find a project from $($Path)"

--- a/BuildHelpers/Public/Get-ProjectName.ps1
+++ b/BuildHelpers/Public/Get-ProjectName.ps1
@@ -13,6 +13,7 @@ function Get-ProjectName {
             * Subfolder with the same name as the current folder
             * Subfolder with a <subfolder-name>.psd1 file in it
             * Current folder with a <currentfolder-name>.psd1 file in it
+            + Subfolder called "Source" or "src" (not case-sensitivve) with a psd1 file in it
 
     .PARAMETER Path
         Path to project root. Defaults to the current working path


### PR DESCRIPTION
## Description
Modifies `Get-ProjectName`, adding additional logic for handling `source` and `src` folders in project layout.

## Related Issue
+ Resolves RamblingCookieMonster/BuildHelpers#19

## Motivation and Context
This allows users who organize their projects using a `source` or `src` folder to utilize BuildHelpers.

## How Has This Been Tested?
Executed against a local project, ran the psake tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.