### PR TITLE
Add default output for Get-ProjectName

### DIFF
--- a/BuildHelpers/BuildHelpers.psd1
+++ b/BuildHelpers/BuildHelpers.psd1
@@ -4,7 +4,7 @@
 RootModule = 'BuildHelpers.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.28'
+ModuleVersion = '0.0.31'
 
 # ID used to uniquely identify this module
 GUID = 'ec079170-28b7-40b4-aaae-f8ebf76850ab'
@@ -58,7 +58,7 @@ PowerShellVersion = '3.0'
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = '*'
+FunctionsToExport = @('Export-Metadata','Find-NugetPackage','Get-BuildVariables','Get-GitChangedFile','Get-Metadata','Get-ModuleFunctions','Get-NextNugetPackageVersion','Get-NextPSGalleryVersion','Get-ProjectName','Get-PSModuleManifest','Invoke-Git','Set-BuildEnvironment','Set-ModuleFormats','Set-ModuleFunctions','Step-ModuleVersion','Step-Version','Update-Metadata','Set-BuildVariable')
 
 # Cmdlets to export from this module
 CmdletsToExport = '*'
@@ -109,3 +109,5 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
+
+

--- a/BuildHelpers/BuildHelpers.psd1
+++ b/BuildHelpers/BuildHelpers.psd1
@@ -4,7 +4,7 @@
 RootModule = 'BuildHelpers.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.31'
+ModuleVersion = '0.0.28'
 
 # ID used to uniquely identify this module
 GUID = 'ec079170-28b7-40b4-aaae-f8ebf76850ab'
@@ -58,7 +58,7 @@ PowerShellVersion = '3.0'
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = @('Export-Metadata','Find-NugetPackage','Get-BuildVariables','Get-GitChangedFile','Get-Metadata','Get-ModuleFunctions','Get-NextNugetPackageVersion','Get-NextPSGalleryVersion','Get-ProjectName','Get-PSModuleManifest','Invoke-Git','Set-BuildEnvironment','Set-ModuleFormats','Set-ModuleFunctions','Step-ModuleVersion','Step-Version','Update-Metadata','Set-BuildVariable')
+FunctionsToExport = '*'
 
 # Cmdlets to export from this module
 CmdletsToExport = '*'
@@ -109,5 +109,3 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
-
-

--- a/BuildHelpers/Public/Get-ProjectName.ps1
+++ b/BuildHelpers/Public/Get-ProjectName.ps1
@@ -71,7 +71,8 @@ function Get-ProjectName {
         }
         else
         {
-            Write-Warning "Could not find a project from $($Path)"
+            Write-Warning "Could not find a project from $($Path); defaulting to project root for name"
+            Split-Path $Path -Leaf
         }
     }
 }

--- a/BuildHelpers/Public/Get-ProjectName.ps1
+++ b/BuildHelpers/Public/Get-ProjectName.ps1
@@ -14,6 +14,9 @@ function Get-ProjectName {
             * Subfolder with a <subfolder-name>.psd1 file in it
             * Current folder with a <currentfolder-name>.psd1 file in it
 
+        If no suitable project name is discovered, the function will return
+        the name of the root folder as the project name.
+
     .PARAMETER Path
         Path to project root. Defaults to the current working path
 


### PR DESCRIPTION
Adds a default output for `Get-ProjectName` if all other methods fail.

## Description
Updates the warning if no valid project names are discovered from looking in the project root's path and returns the project root's folder name as the project name.

## Related Issue
Resolves RamblingCookieMonster/BuildHelpers#20

## Motivation and Context
A project should return _some_ value for its name even if discovery methods fail; defaulting to the name of the project root's folder is a sane default - the function should still publish a warning to the user so they're aware of this.

## How Has This Been Tested?
Executed locally and psake tests executed successfully.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Since this causes the function to return data instead of being null, this is a backward-breaking change.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.