### PR TITLE
Ensure source folder layout works for project name and manifest

### DIFF
--- a/BuildHelpers/Public/Get-PSModuleManifest.ps1
+++ b/BuildHelpers/Public/Get-PSModuleManifest.ps1
@@ -13,6 +13,7 @@
             * Subfolder with the same name as the current folder with a psd1 file in it
             * Subfolder with a <subfolder-name>.psd1 file in it
             * Current folder with a <currentfolder-name>.psd1 file in it
+            + Subfolder called "Source" or "src" (not case-sensitive) with a psd1 file in it
 
         Note: This does not handle paths in the format Folder\ModuleName\Version\
 
@@ -75,6 +76,15 @@
         elseif( Test-Path "$ExpectedPath.psd1" )
         {
             "$ExpectedPath.psd1"
+        }
+        # PSD1 in Source or Src folder
+        elseif( Get-Item "$Path\S*rc*\*.psd1" -OutVariable SourceManifests)
+        {
+            If ( $SourceManifests.Count -gt 1 )
+            {
+                Write-Warning "Found more than one project manifest in the Source folder"
+            }
+            $SourceManifests.BaseName
         }
         else
         {

--- a/BuildHelpers/Public/Get-ProjectName.ps1
+++ b/BuildHelpers/Public/Get-ProjectName.ps1
@@ -13,7 +13,7 @@ function Get-ProjectName {
             * Subfolder with the same name as the current folder
             * Subfolder with a <subfolder-name>.psd1 file in it
             * Current folder with a <currentfolder-name>.psd1 file in it
-            + Subfolder called "Source" or "src" (not case-sensitivve) with a psd1 file in it
+            + Subfolder called "Source" or "src" (not case-sensitive) with a psd1 file in it
 
         If no suitable project name is discovered, the function will return
         the name of the root folder as the project name.
@@ -74,7 +74,7 @@ function Get-ProjectName {
             $CurrentFolder
         }
         # PSD1 in Source or Src folder
-        elseif( Get-Item "$Path\S*rc*\*.psd1", -OutVariable SourceManifests)
+        elseif( Get-Item "$Path\S*rc*\*.psd1" -OutVariable SourceManifests)
         {
             If ( $SourceManifests.Count -gt 1 )
             {


### PR DESCRIPTION
## Description
+ Fixed a minor bug in the comment-based help for Get-ProjectName
+ Removed extraneous comma from Get-ProjectName
+ Added functionality to Get-PSModuleManifest to allow discovery
of manifests when the project is organized to use a source or src
folder layout.
+ Updated comment-based help for Get-PSModuleManifest to reflect
the new capability.

## Related Issue
+ Resolves RamblingCookieMonster/BuildHelpers#23

## Motivation and Context
This allows users who organize their projects using a `source` or `src` folder to utilize BuildHelpers.

## How Has This Been Tested?
Executed against a local project, ran the psake tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.