### PR TITLE
Ensure Get-PSModuleManifest returns full path

### DIFF
--- a/BuildHelpers/Public/Get-PSModuleManifest.ps1
+++ b/BuildHelpers/Public/Get-PSModuleManifest.ps1
@@ -84,7 +84,7 @@
             {
                 Write-Warning "Found more than one project manifest in the Source folder"
             }
-            $SourceManifests.BaseName
+            $SourceManifests.FullName
         }
         else
         {


### PR DESCRIPTION
+ The function was returning the basename instead of the fullname, and so the path
did not resolve properly. Fixed.

Sorry for submitting so many PRs recently, I guess I accidentally reverted the file before the previous PR - it should now return the full paths to the manifests instead of their base name.