### PR TITLE
add environment Variable prefix as per Set-BuildVariable.ps1

### DIFF
--- a/BuildHelpers/Public/Add-TestResultToAppveyor.ps1
+++ b/BuildHelpers/Public/Add-TestResultToAppveyor.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+    Short description
+
+.DESCRIPTION
+    Long description
+
+.EXAMPLE
+    Example of how to use this cmdlet
+
+.EXAMPLE
+    Another example of how to use this cmdlet
+
+.INPUTS
+    Inputs to this cmdlet (if any)
+
+.OUTPUTS
+    Output from this cmdlet (if any)
+
+.NOTES
+    General notes
+#>
+function Add-TestResultToAppveyor {
+    [CmdletBinding()]
+    [OutputType([void])]
+    Param (
+        # Appveyor Job ID
+        [int]
+        $APPVEYOR_JOB_ID = $Env:APPVEYOR_JOB_ID,
+
+        [ValidateSet('mstest','xunit','nunit','nunit3','junit')]
+        $ResultType = 'nunit',
+
+        # List of files to be uploaded
+        [Parameter(Mandatory,
+                   Position,
+                   ValueFromPipeline,
+                   ValueFromPipelineByPropertyName,
+                   ValueFromRemainingArguments
+        )]
+        [Alias("Path")]
+        [string[]]
+        $TestFile
+    )
+    
+    begin {
+            $wc = New-Object 'System.Net.WebClient'
+    }
+    
+    process {
+        foreach ($File in $TestFile) {
+            if (Test-Path $File) {
+                Write-Verbose "Uploading $File for Job ID: $APPVEYOR_JOB_ID"
+                $wc.UploadFile("https://ci.appveyor.com/api/testresults/$ResultType/$($APPVEYOR_JOB_ID)", $File)
+            }
+        }
+    }
+    
+    end {
+        $wc.Dispose()
+    }
+}

--- a/BuildHelpers/Public/Add-TestResultToAppveyor.ps1
+++ b/BuildHelpers/Public/Add-TestResultToAppveyor.ps1
@@ -25,7 +25,7 @@ function Add-TestResultToAppveyor {
     [OutputType([void])]
     Param (
         # Appveyor Job ID
-        [int]
+        [String]
         $APPVEYOR_JOB_ID = $Env:APPVEYOR_JOB_ID,
 
         [ValidateSet('mstest','xunit','nunit','nunit3','junit')]
@@ -38,7 +38,7 @@ function Add-TestResultToAppveyor {
                    ValueFromPipelineByPropertyName,
                    ValueFromRemainingArguments
         )]
-        [Alias("Path")]
+        [Alias("FullName")]
         [string[]]
         $TestFile
     )

--- a/BuildHelpers/Public/Add-TestResultToAppveyor.ps1
+++ b/BuildHelpers/Public/Add-TestResultToAppveyor.ps1
@@ -1,26 +1,20 @@
-<#
-.SYNOPSIS
-    Short description
-
-.DESCRIPTION
-    Long description
-
-.EXAMPLE
-    Example of how to use this cmdlet
-
-.EXAMPLE
-    Another example of how to use this cmdlet
-
-.INPUTS
-    Inputs to this cmdlet (if any)
-
-.OUTPUTS
-    Output from this cmdlet (if any)
-
-.NOTES
-    General notes
-#>
 function Add-TestResultToAppveyor {
+    <#
+    .SYNOPSIS
+        Upload test results to AppVeyor
+
+    .DESCRIPTION
+        Upload test results to AppVeyor
+
+    .EXAMPLE
+        Add-TestResultToAppVeyor -TestFile C:\testresults.xml
+
+    .LINK
+        https://github.com/RamblingCookieMonster/BuildHelpers
+
+    .LINK
+        about_BuildHelpers
+    #>
     [CmdletBinding()]
     [OutputType([void])]
     Param (
@@ -42,11 +36,11 @@ function Add-TestResultToAppveyor {
         [string[]]
         $TestFile
     )
-    
+
     begin {
             $wc = New-Object 'System.Net.WebClient'
     }
-    
+
     process {
         foreach ($File in $TestFile) {
             if (Test-Path $File) {
@@ -55,7 +49,7 @@ function Add-TestResultToAppveyor {
             }
         }
     }
-    
+
     end {
         $wc.Dispose()
     }

--- a/BuildHelpers/Public/Set-BuildEnvironment.ps1
+++ b/BuildHelpers/Public/Set-BuildEnvironment.ps1
@@ -38,7 +38,7 @@ function Set-BuildEnvironment {
     .EXAMPLE
         Set-BuildEnvironment -VariableNamePrefix '' -Force
 
-        Get-Item ENV:* 
+        Get-Item ENV:*
 
     .LINK
         https://github.com/RamblingCookieMonster/BuildHelpers
@@ -67,6 +67,10 @@ function Set-BuildEnvironment {
     ${Build.Vars} = Get-BuildVariables -Path $Path
     ${Build.ProjectName} = Get-ProjectName -Path $Path
     ${Build.ManifestPath} = Get-PSModuleManifest -Path $Path
+    if( ${Build.ManifestPath} )
+    {
+        ${Build.ModulePath} = Split-Path -Path ${Build.ManifestPath} -Parent
+    }
     $BuildHelpersVariables = @{
         BuildSystem = ${Build.Vars}.BuildSystem
         ProjectPath = ${Build.Vars}.ProjectPath
@@ -75,7 +79,7 @@ function Set-BuildEnvironment {
         BuildNumber = ${Build.Vars}.BuildNumber
         ProjectName = ${Build.ProjectName}
         PSModuleManifest = ${Build.ManifestPath}
-        PSModulePath = $(Split-Path -Path ${Build.ManifestPath} -Parent)
+        PSModulePath = ${Build.ModulePath}
     }
     foreach ($VarName in $BuildHelpersVariables.Keys) {
         New-Item -Path Env:\ -Name ('{0}{1}' -f $VariableNamePrefix,$VarName) -Value $BuildHelpersVariables[$VarName] -Force:$Force

--- a/BuildHelpers/Public/Set-BuildEnvironment.ps1
+++ b/BuildHelpers/Public/Set-BuildEnvironment.ps1
@@ -24,6 +24,9 @@ function Set-BuildEnvironment {
     .PARAMETER VariableNamePrefix
         Allow to set a custom Prefix to the Environment variable created. The default is BH such as $Env:BHProjectPath
 
+    .PARAMETER Passthru
+        If specified, include output of the build variables we create
+
     .PARAMETER Force
         Overrides the Environment Variables even if they exist already
 
@@ -82,6 +85,10 @@ function Set-BuildEnvironment {
         PSModulePath = ${Build.ModulePath}
     }
     foreach ($VarName in $BuildHelpersVariables.Keys) {
-        New-Item -Path Env:\ -Name ('{0}{1}' -f $VariableNamePrefix,$VarName) -Value $BuildHelpersVariables[$VarName] -Force:$Force
+        $Output = New-Item -Path Env:\ -Name ('{0}{1}' -f $VariableNamePrefix,$VarName) -Value $BuildHelpersVariables[$VarName] -Force:$Force
+        if($Passthru)
+        {
+            $Output
+        }
     }
 }

--- a/BuildHelpers/Scripts/Set-BuildVariable.ps1
+++ b/BuildHelpers/Scripts/Set-BuildVariable.ps1
@@ -29,6 +29,9 @@
 
     The scope value Script may only be used with dot-sourced Set-BuildVariable.
 
+.PARAMETER VariableNamePrefix
+    Allow to set a custom Prefix to the Environment variable created. The default is BH such as $BHProjectPath
+
 .NOTES
     We assume you are in the project root, for several of the fallback options
 
@@ -41,6 +44,12 @@
 .EXAMPLE
     . Set-BuildVariable -Scope Script
     Get-Variable BH* -Scope Script
+
+    # Set build variables in the script scope (mind the .), read them
+
+.EXAMPLE
+    . Set-BuildVariable -VariableNamePrefix BUILD
+    Get-Variable BUILD*
 
     # Set build variables in the script scope (mind the .), read them
 


### PR DESCRIPTION
Hi,
This feature allows to change the prefix for the environment variable names, default is 'BH' for backward compatibility.

I've also extracted a function to upload the test results to AppVeyor, and tested that [here](https://ci.appveyor.com/project/gaelcolas/samplemodule/build/tests).
