### PR TITLE
Preserve BuildOutput parameter through Set

### DIFF
--- a/BuildHelpers/Public/Set-BuildEnvironment.ps1
+++ b/BuildHelpers/Public/Set-BuildEnvironment.ps1
@@ -109,6 +109,7 @@ function Set-BuildEnvironment {
     $GBEParams = @{
         Path = $Path
         As = 'hashtable'
+        BuildOutput = $BuildOutput
     }
     if($PSBoundParameters.ContainsKey('GitPath')) {
         $GBEParams.add('GitPath', $GitPath)


### PR DESCRIPTION
When Get-BuildEnvironment runs at line 117, the BuildOutput parameter isn't passed and thus it generates the default every time, thus Set-BuildEnvironment always does $Projectpath\BuildOutput no matter what. Adding the parameter to pass through via GBEParms will preserve it and ensure it gets set correctly.