### PR TITLE
Removing Dependency on .exe for Git

### DIFF
--- a/BuildHelpers/Public/Get-BuildEnvironment.ps1
+++ b/BuildHelpers/Public/Get-BuildEnvironment.ps1
@@ -33,7 +33,7 @@ function Get-BuildEnvironment {
             -BuildOutput 'C:\Builds\$ProjectName'
 
     .PARAMETER GitPath
-        Path to git.exe.  Defaults to git.exe (i.e. git.exe is in $ENV:PATH)
+        Path to git.  Defaults to git (i.e. git is in $ENV:PATH)
 
     .NOTES
         We assume you are in the project root, for several of the fallback options

--- a/BuildHelpers/Public/Get-BuildVariables.ps1
+++ b/BuildHelpers/Public/Get-BuildVariables.ps1
@@ -39,7 +39,7 @@ function Get-BuildVariables {
         Path to project root. Defaults to the current working path
 
     .PARAMETER GitPath
-        Path to git.exe.  Defaults to git.exe (i.e. git.exe is in $ENV:PATH)
+        Path to git.  Defaults to git (i.e. git is in $ENV:PATH)
 
     .NOTES
         We assume you are in the project root, for several of the fallback options
@@ -69,11 +69,15 @@ function Get-BuildVariables {
             }
             $true
         })]
-        $GitPath = 'git.exe'
+        $GitPath = 'git'
     )
 
     $Path = ( Resolve-Path $Path ).Path
     $Environment = Get-Item ENV:
+    if(!$PSboundParameters.ContainsKey('GitPath')) {
+        $GitPath = (Get-Command $GitPath)[0].Path
+    }
+    
     $WeCanGit = ( (Test-Path $( Join-Path $Path .git )) -and (Get-Command $GitPath -ErrorAction SilentlyContinue) )
     if($WeCanGit)
     {

--- a/BuildHelpers/Public/Invoke-Git.ps1
+++ b/BuildHelpers/Public/Invoke-Git.ps1
@@ -83,7 +83,7 @@
     $Path = (Resolve-Path $Path).Path
     # http://stackoverflow.com/questions/8761888/powershell-capturing-standard-out-and-error-with-start-process
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
-    if(!$PSBoundParameters.ContainsKey()) {
+    if(!$PSBoundParameters.ContainsKey('GitPath')) {
         $GitPath = (Get-Command $GitPath)[0].Path
     }
     $pinfo.FileName = $GitPath

--- a/BuildHelpers/Public/Invoke-Git.ps1
+++ b/BuildHelpers/Public/Invoke-Git.ps1
@@ -77,12 +77,15 @@
             }
             $true
         })]
-        [string]$GitPath = 'git.exe'
+        [string]$GitPath = 'git'
     )
 
     $Path = (Resolve-Path $Path).Path
     # http://stackoverflow.com/questions/8761888/powershell-capturing-standard-out-and-error-with-start-process
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+    if(!$PSBoundParameters.ContainsKey()) {
+        $GitPath = (Get-Command $GitPath)[0].Path
+    }
     $pinfo.FileName = $GitPath
     $Command = $GitPath
     $pinfo.CreateNoWindow = $NoWindow

--- a/BuildHelpers/Public/Invoke-Git.ps1
+++ b/BuildHelpers/Public/Invoke-Git.ps1
@@ -1,13 +1,13 @@
 ﻿Function Invoke-Git {
 <#
     .SYNOPSIS
-        Wrapper to invoke git.exe and return streams
+        Wrapper to invoke git and return streams
 
     .FUNCTIONALITY
         CI/CD
 
     .DESCRIPTION
-        Wrapper to invoke git.exe and return streams
+        Wrapper to invoke git and return streams
 
     .PARAMETER Arguments
         If specified, call git with these arguments.
@@ -15,7 +15,7 @@
         This takes a positional argument and accepts all value afterwards for a more natural 'git-esque' use.
 
     .PARAMETER Path
-        Working directory to launch git.exe within.  Defaults to current location
+        Working directory to launch git within.  Defaults to current location
 
     .PARAMETER RedirectStandardError
         Whether to capture standard error.  Defaults to $true
@@ -38,7 +38,7 @@
         If specified, do not return output
 
     .PARAMETER GitPath
-        Path to git.exe.  Defaults to git.exe (i.e. git.exe is in $ENV:PATH)
+        Path to git.  Defaults to git (i.e. git is in $ENV:PATH)
 
     .EXAMPLE
         Invoke-Git rev-parse HEAD

--- a/BuildHelpers/Public/Set-BuildEnvironment.ps1
+++ b/BuildHelpers/Public/Set-BuildEnvironment.ps1
@@ -42,7 +42,7 @@ function Set-BuildEnvironment {
         If specified, include output of the build variables we create
 
     .PARAMETER GitPath
-        Path to git.exe.  Defaults to git.exe (i.e. git.exe is in $ENV:PATH)
+        Path to git.  Defaults to git (i.e. git is in $ENV:PATH)
 
     .PARAMETER Force
         Overrides the Environment Variables even if they exist already


### PR DESCRIPTION
The code was looking for the `git.exe` command by default.
That's been a problem for me as sometimes my environments only rely on ChefDK's integrated git which is `git.cmd`, and could be a problem on non windows machine as well.

I've changed the references to use `(Get-Command 'git')[0].Path` when the Git path is not specified.

There should be no breaking change, but worth doing more testing your end.

I'm also considering putting the line above directly into the Default parameters value, up to you really.

Gael