### PR TITLE
Improvements to Module Manifest's FunctionsToExport & AliasesToExport plus Get-NextPSGalleryVersion

### DIFF
--- a/Build/build.requirements.psd1
+++ b/Build/build.requirements.psd1
@@ -11,11 +11,11 @@
     }
     'PSDeploy' = @{
         DependencyType = 'PSGalleryNuget'
-        Version = '0.1.26'
+        Version = '0.2.2'
     }
     'BuildHelpers' = @{
         DependencyType = 'PSGalleryNuget'
-        Version = '0.0.34'
+        Version = '0.0.57'
     }
     'Pester' = @{
         DependencyType = 'PSGalleryNuget'

--- a/Build/psake.ps1
+++ b/Build/psake.ps1
@@ -58,15 +58,18 @@ Task Test -Depends Init  {
 
 Task Build -Depends Test {
     $lines
-    
+
     # Load the module, read the exported functions, update the psd1 FunctionsToExport
     Set-ModuleFunctions
 
-    # Bump the module version
+    # Bump the module version if we didn't already
     Try
     {
-        $Version = Get-NextPSGalleryVersion -Name $env:BHProjectName -ErrorAction Stop
-        Update-Metadata -Path $env:BHPSModuleManifest -PropertyName ModuleVersion -Value $Version -ErrorAction stop
+        [version]$GalleryVersion = Get-NextPSGalleryVersion -Name $env:BHProjectName -ErrorAction Stop
+        [version]$GithubVersion = Get-MetaData -Path $env:BHPSModuleManifest -PropertyName ModuleVersion -ErrorAction Stop
+        if($GalleryVersion -ge $GithubVersion) {
+            Update-Metadata -Path $env:BHPSModuleManifest -PropertyName ModuleVersion -Value $GalleryVersion -ErrorAction stop
+        }
     }
     Catch
     {

--- a/BuildHelpers/BuildHelpers.psd1
+++ b/BuildHelpers/BuildHelpers.psd1
@@ -4,7 +4,7 @@
 RootModule = 'BuildHelpers.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.0.28'
+ModuleVersion = '1.0.0'
 
 # ID used to uniquely identify this module
 GUID = 'ec079170-28b7-40b4-aaae-f8ebf76850ab'

--- a/BuildHelpers/Public/Get-ModuleAliases.ps1
+++ b/BuildHelpers/Public/Get-ModuleAliases.ps1
@@ -1,0 +1,59 @@
+function Get-ModuleAliases {
+    <#
+    .SYNOPSIS
+        List aliases imported by a module
+
+    .FUNCTIONALITY
+        CI/CD
+
+    .DESCRIPTION
+        List aliases imported by a module. Note that this actually imports the module.
+
+    .PARAMETER Name
+        Name or path to module to inspect.  Defaults to ProjectPath\ProjectName
+
+    .NOTES
+        We assume you are in the project root, for several of the fallback options
+
+    .EXAMPLE
+        Get-ModuleAliases
+
+    .LINK
+        https://github.com/RamblingCookieMonster/BuildHelpers
+
+    .LINK
+        about_BuildHelpers
+    #>
+    [cmdletbinding()]
+    param(
+        [parameter(ValueFromPipeline = $True)]
+        [Alias('Path')]
+        [string]$Name
+    )
+    Process
+    {
+        if(-not $Name)
+        {
+            $BuildDetails = Get-BuildVariables
+            $Name = Join-Path ($BuildDetails.ProjectPath) (Get-ProjectName)
+        }
+
+        $params = @{
+            Force = $True
+            Passthru = $True
+            Name = $Name
+        }
+
+        # Create a runspace, add script to run
+        $PowerShell = [Powershell]::Create()
+        [void]$PowerShell.AddScript({
+            Param ($Force, $Passthru, $Name)
+            Import-Module -Name $Name -PassThru:$Passthru -Force:$Force
+
+        }).AddParameters($Params)
+
+        ( $PowerShell.Invoke() ).ExportedAliases.Keys
+
+        $PowerShell.Dispose()
+    }
+}

--- a/BuildHelpers/Public/Get-ModuleFunctions.ps1
+++ b/BuildHelpers/Public/Get-ModuleFunctions.ps1
@@ -52,7 +52,7 @@ function Get-ModuleFunctions {
 
         }).AddParameters($Params)
 
-        ( $PowerShell.Invoke() ).ExportedCommands.Keys
+        ( $PowerShell.Invoke() ).ExportedFunctions.Keys
 
         $PowerShell.Dispose()
     }

--- a/BuildHelpers/Public/Get-NextPSGalleryVersion.ps1
+++ b/BuildHelpers/Public/Get-NextPSGalleryVersion.ps1
@@ -41,84 +41,73 @@
     #>
     [cmdletbinding()]
     param(
-        [parameter(ValueFromPipelineByPropertyName=$True)]
+        [parameter(ValueFromPipelineByPropertyName = $True)]
         [string[]]$Name,
 
-        [parameter(ValueFromPipelineByPropertyName=$True)]
+        [parameter(ValueFromPipelineByPropertyName = $True)]
         [ValidateSet('Module', 'Script')]
         [string]$Type = 'Module',
 
         [string]$Repository = 'PSGallery'
     )
-    Process
-    {
-        foreach($Item in $Name)
-        {
-            Try
-            {
+    Begin {
+        Write-Warning "DEPRECATED: Please use Get-NextNugetPackageVersion"
+    }
+    Process {
+        foreach ($Item in $Name) {
+            Try {
                 $Existing = $null
-                if($Type -eq 'Module')
-                {
+                if ($Type -eq 'Module') {
                     $Existing = Find-Module -Name $Item -Repository $Repository -ErrorAction Stop
                 }
-                else # Script
-                {
+                else { 
+                    # Script
                     $Existing = Find-Script -Name $Item -Repository $Repository -ErrorAction Stop
                 }
             }
-            Catch
-            {
-                if($_ -match "No match was found for the specified search criteria")
-                {
-                    New-Object System.Version (0,0,1)
+            Catch {
+                if ($_ -match "No match was found for the specified search criteria") {
+                    New-Object System.Version (0, 0, 1)
                 }
-                else
-                {
+                else {
                     Write-Error $_
                 }
                 continue
             }
 
-            if($Existing.count -gt 1)
-            {
+            if ($Existing.count -gt 1) {
                 Write-Error "Found more than one $Type matching '$Item': Did you use a wildcard?"
                 continue
             }
-            elseif($Existing.count -eq 0)
-            {
+            elseif ($Existing.count -eq 0) {
                 Write-Verbose "Found no $Type matching '$Item'"
-                New-Object System.Version (0,0,1)
+                New-Object System.Version (0, 0, 1)
                 continue
             }
-            else
-            {
+            else {
                 $Version = $Existing.Version
             }
 
             # using revision
-            if($Version.Revision -ge 0)
-            {
-                $Build = if($Version.Build -le 0) { 0 } else { $Version.Build }
-                $Revision = if($Version.Revision -le 0) { 1 } else { $Version.Revision + 1 }
+            if ($Version.Revision -ge 0) {
+                $Build = if ($Version.Build -le 0) { 0 } else { $Version.Build }
+                $Revision = if ($Version.Revision -le 0) { 1 } else { $Version.Revision + 1 }
                 New-Object System.Version ($Version.Major, $Version.Minor, $Build, $Revision)
             }
             # using build
-            elseif($Version.Build -ge 0)
-            {
-                $Build = if($Version.Build -le 0) { 1 } else { $Version.Build + 1 }
+            elseif ($Version.Build -ge 0) {
+                $Build = if ($Version.Build -le 0) { 1 } else { $Version.Build + 1 }
                 New-Object System.Version ($Version.Major, $Version.Minor, $Build)
             }
             # using minor. wat?
-            elseif($Version.Minor -ge 0)
-            {
-                $Minor = if($Version.Minor -le 0) { 1 } else { $Version.Minor + 1 }
+            elseif ($Version.Minor -ge 0) {
+                $Minor = if ($Version.Minor -le 0) { 1 } else { $Version.Minor + 1 }
                 New-Object System.Version ($Version.Major, $Minor)
             }
             # using major only. I don't even.
-            else
-            {
+            else {
                 New-Object System.Version ($Version.Major + 1, 0)
             }
-        }
-    }
+        }   
+}
 }

--- a/BuildHelpers/Public/Set-ModuleAliases.ps1
+++ b/BuildHelpers/Public/Set-ModuleAliases.ps1
@@ -1,0 +1,84 @@
+function Set-ModuleAliases {
+    <#
+    .SYNOPSIS
+        EXPIRIMENTAL: Set AliasesToExport in a module manifest
+
+    .FUNCTIONALITY
+        CI/CD
+
+    .DESCRIPTION
+        EXPIRIMENTAL: Set AliasesToExport in a module manifest
+
+    .PARAMETER Name
+        Name or path to module to inspect.  Defaults to ProjectPath\ProjectName via Get-BuildVariables
+
+    .NOTES
+        Major thanks to Joel Bennett for the code behind working with the psd1
+            Source: https://github.com/PoshCode/Configuration
+
+    .EXAMPLE
+        Set-ModuleAliases
+
+    .LINK
+        https://github.com/RamblingCookieMonster/BuildHelpers
+
+    .LINK
+        about_BuildHelpers
+    #>
+    [cmdletbinding()]
+    param(
+        [parameter(ValueFromPipeline = $True)]
+        [Alias('Path')]
+        [string]$Name,
+
+        [string[]]$AliasesToExport
+    )
+    Process
+    {
+        if(-not $Name)
+        {
+            $BuildDetails = Get-BuildVariables
+            $Name = Join-Path ($BuildDetails.ProjectPath) (Get-ProjectName)
+        }
+
+        $params = @{
+            Force = $True
+            Passthru = $True
+            Name = $Name
+        }
+
+        # Create a runspace, add script to run
+        $PowerShell = [Powershell]::Create()
+        [void]$PowerShell.AddScript({
+            Param ($Force, $Passthru, $Name)
+            $module = Import-Module -Name $Name -PassThru:$Passthru -Force:$Force
+            $module | Where-Object Path -notin $module.Scripts
+
+        }).AddParameters($Params)
+
+        #Consider moving this to a runspace or job to keep session clean
+        $Module = $PowerShell.Invoke()
+        if(-not $Module)
+        {
+            Throw "Could not find module '$Name'"
+        }
+
+        if(-not $AliasesToExport)
+        {
+            $AliasesToExport = @( $Module.ExportedAliases.Keys )
+        }
+
+        $Parent = $Module.ModuleBase
+        $File = "$($Module.Name).psd1"
+        $ModulePSD1Path = Join-Path $Parent $File
+        if(-not (Test-Path $ModulePSD1Path))
+        {
+            Throw "Could not find expected module manifest '$ModulePSD1Path'"
+        }
+
+        Update-MetaData -Path $ModulePSD1Path -PropertyName AliasesToExport -Value $AliasesToExport
+        
+        # Close down the runspace
+        $PowerShell.Dispose()
+    }
+}

--- a/BuildHelpers/Public/Set-ModuleFunctions.ps1
+++ b/BuildHelpers/Public/Set-ModuleFunctions.ps1
@@ -65,7 +65,7 @@ function Set-ModuleFunctions {
 
         if(-not $FunctionsToExport)
         {
-            $FunctionsToExport = @( $Module.ExportedCommands.Keys )
+            $FunctionsToExport = @( $Module.ExportedFunctions.Keys )
         }
 
         $Parent = $Module.ModuleBase


### PR DESCRIPTION
Fork reset, force push, and a few fresh commits later, now have a cleaner PR compared to #51. Repeating the motivation behind the content of each commit.

- 46cfdf7 - My module also exports aliases so ExportedCommands in Get/Set-ModuleFunctions was too broad. Modified the functions to use ExportedFunctions instead of ExportedCommands so that FunctionsToExport in the module manifest contained only functions.
- 63bbd71 - In the spirit of Get/Set-ModuleFunctions, I created Get/Set-ModuleAliases functions to manage my module manifest's AliasesToExport key. My module defines aliases for some functions by appending the New-Alias command after the function definition. So to get the aliases into my module's ExportedAliases, my module's psm1 file executes Export-ModuleMember -Alias (Get-Alias | Where-Object {$_.ResolvedCommandName -in $Public.Basename}).Name.
- 8df6fea - Struggled in getting the next version number from the internal repo until I read the documentation of Get-NextPSGalleryVersion that directed me to Get-NextNugetPackageVersion instead. Added a warning to Get-NextPSGalleryVersion to display the deprecation notice on execution yet keep the command functional.
