### PR TITLE
Uses AppVeyor Project if available

### DIFF
--- a/BuildHelpers/Public/Get-ProjectName.ps1
+++ b/BuildHelpers/Public/Get-ProjectName.ps1
@@ -1,4 +1,5 @@
-function Get-ProjectName {
+function Get-ProjectName
+{
     <#
     .SYNOPSIS
         Get the name for this project
@@ -44,39 +45,35 @@ function Get-ProjectName {
         $Path = $PWD.Path
     )
     
-    if ($env:APPVEYOR_PROJECT_NAME -and $env:APPVEYOR_JOB_ID) {
-        return $env:APPVEYOR_PROJECT_NAME
-    }
-    
     $Path = ( Resolve-Path $Path ).Path
     $CurrentFolder = Split-Path $Path -Leaf
     $ExpectedPath = Join-Path -Path $Path -ChildPath $CurrentFolder
     if(Test-Path $ExpectedPath)
     {
-        $CurrentFolder
+        $result = $CurrentFolder
     }
     else
     {
         # Look for properly organized modules
         $ProjectPaths = Get-ChildItem $Path -Directory |
             Where-Object {
-                Test-Path $(Join-Path $_.FullName "$($_.name).psd1")
-            } |
+            Test-Path $(Join-Path $_.FullName "$($_.name).psd1")
+        } |
             Select -ExpandProperty Fullname
 
         if( @($ProjectPaths).Count -gt 1 )
         {
             Write-Warning "Found more than one project path via subfolders with psd1 files"
-            Split-Path $ProjectPaths -Leaf
+            $result = Split-Path $ProjectPaths -Leaf
         }
         elseif( @($ProjectPaths).Count -eq 1 )
         {
-            Split-Path $ProjectPaths -Leaf
+            $result = Split-Path $ProjectPaths -Leaf
         }
         #PSD1 in root of project - ick, but happens.
         elseif( Test-Path "$ExpectedPath.psd1" )
         {
-            $CurrentFolder
+            $result = $CurrentFolder
         }
         # PSD1 in Source or Src folder
         elseif( Get-Item "$Path\S*rc*\*.psd1" -OutVariable SourceManifests)
@@ -85,12 +82,21 @@ function Get-ProjectName {
             {
                 Write-Warning "Found more than one project manifest in the Source folder"
             }
-            $SourceManifests.BaseName
+            $result = $SourceManifests.BaseName
         }
         else
         {
             Write-Warning "Could not find a project from $($Path); defaulting to project root for name"
-            Split-Path $Path -Leaf
+            $result = Split-Path $Path -Leaf
         }
+    }
+    
+    if ($env:APPVEYOR_PROJECT_NAME -and $env:APPVEYOR_JOB_ID -and ($result -like $env:APPVEYOR_PROJECT_NAME))
+    {
+        $env:APPVEYOR_PROJECT_NAME
+    }
+    else
+    {
+        $result
     }
 }

--- a/BuildHelpers/Public/Get-ProjectName.ps1
+++ b/BuildHelpers/Public/Get-ProjectName.ps1
@@ -43,6 +43,11 @@ function Get-ProjectName {
     param(
         $Path = $PWD.Path
     )
+    
+    if ($env:APPVEYOR_PROJECT_NAME -and $env:APPVEYOR_JOB_ID) {
+        return $env:APPVEYOR_PROJECT_NAME
+    }
+    
     $Path = ( Resolve-Path $Path ).Path
     $CurrentFolder = Split-Path $Path -Leaf
     $ExpectedPath = Join-Path -Path $Path -ChildPath $CurrentFolder

--- a/Tests/BuildHelpers.Tests.ps1
+++ b/Tests/BuildHelpers.Tests.ps1
@@ -27,13 +27,6 @@ Describe "$ModuleName PS$PSVersion" {
 }
 
 Describe "Get-ProjectName PS$PSVersion" {
-    BeforeAll {
-        $script:TempProjectName = $env:BHProjectName
-        Remove-Item Env:BHProjectName
-    }
-    AfterAll {
-        $env:BHProjectName = $script:TempProjectName
-    }
     Context 'Strict mode' {
 
         Set-StrictMode -Version latest

--- a/Tests/BuildHelpers.Tests.ps1
+++ b/Tests/BuildHelpers.Tests.ps1
@@ -27,6 +27,13 @@ Describe "$ModuleName PS$PSVersion" {
 }
 
 Describe "Get-ProjectName PS$PSVersion" {
+    BeforeAll {
+        $script:TempProjectName = $env:BHProjectName
+        Remove-Item Env:BHProjectName
+    }
+    AfterAll {
+        $env:BHProjectName = $script:TempProjectName
+    }
     Context 'Strict mode' {
 
         Set-StrictMode -Version latest


### PR DESCRIPTION
The capitalization of folder is lost with the way AppVeyor clones a repository.
This makes Get-ProjectName use AppVeyor's ProjectName if available