### PR TITLE
Improved loading of Configuration module

### DIFF
--- a/BuildHelpers/BuildHelpers.psm1
+++ b/BuildHelpers/BuildHelpers.psm1
@@ -1,25 +1,37 @@
 #Get public and private function definition files.
-    $Public  = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue )
-    $Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue )
-    $ModuleRoot = $PSScriptRoot
+$Public  = @( Get-ChildItem -Path $PSScriptRoot\Public\*.ps1 -ErrorAction SilentlyContinue )
+$Private = @( Get-ChildItem -Path $PSScriptRoot\Private\*.ps1 -ErrorAction SilentlyContinue )
+$ModuleRoot = $PSScriptRoot
 
 #Dot source the files
-    Foreach($import in @($Public + $Private))
+Foreach($import in @($Public + $Private))
+{
+    Try
     {
-        Try
-        {
-            . $import.fullname
-        }
-        Catch
-        {
-            Write-Error -Message "Failed to import function $($import.fullname): $_"
-        }
+        . $import.fullname
     }
+    Catch
+    {
+        Write-Error -Message "Failed to import function $($import.fullname): $_"
+    }
+}
 
 # Load dependencies. TODO: Move to module dependency once the bug that
 # causes this is fixed: https://ci.appveyor.com/project/RamblingCookieMonster/buildhelpers/build/1.0.22
 # Thanks to Joel Bennett for this!
-    Import-Module $PSScriptRoot\Private\Modules\Configuration
+$fallbackModule = Get-Module -Name $PSScriptRoot\Private\Modules\Configuration -ListAvailable
+if ($configModule = Get-Module $fallbackModule.Name -ListAvailable)
+{
+    $configModule |
+        Where-Object { $_.Version -gt $fallbackModule.Version} |
+        Sort-Object -Property Version -Descending |
+        Select-Object -First 1 |
+        Import-Module -Force
+}
+if (-not (Get-Module $fallbackModule.Name | Where-Object { $_.Version -gt $fallbackModule.Version}))
+{
+    $fallbackModule | Import-Module -Force
+}
 
 Export-ModuleMember -Function $Public.Basename
 Export-ModuleMember -Function Get-Metadata, Update-Metadata, Export-Metadata


### PR DESCRIPTION
`Configuration` module which is shipped in this repository is now only
loaded when no newer version of `Configuration` could be found on the system

_personally I prefer for the `Configuration` module not to be shipped in the module, as submitted in #60._