### PR TITLE
Changed the way `Set-ModuleFunctions` imports the target module

### DIFF
--- a/BuildHelpers/Public/Set-ModuleFunctions.ps1
+++ b/BuildHelpers/Public/Set-ModuleFunctions.ps1
@@ -36,13 +36,16 @@ function Set-ModuleFunctions {
 
     Process
     {
+        # cache the modules loaded before we start
+        $loadedModules = Get-Module
+
         if(-not $Name)
         {
             $BuildDetails = Get-BuildVariables
             $Name = Join-Path ($BuildDetails.ProjectPath) (Get-ProjectName)
         }
 
-        $Module = Import-Module -Name (Resolve-Path $Name).Path -PassThru -Force -Scope Local
+        $Module = Import-Module -Name (Resolve-Path $Name).Path -PassThru -Force
 
         if(-not $Module)
         {
@@ -62,5 +65,10 @@ function Set-ModuleFunctions {
         }
 
         Update-MetaData -Path $ModulePSD1Path -PropertyName FunctionsToExport -Value $FunctionsToExport
+
+        # remove all modules no in the cache
+        Get-Module |
+            Where-Object { $_ -notin $loadedModules } |
+            Foreach-Object { Remove-Module -ModuleInfo $_ -ErrorAction SilentlyContinue }
     }
 }


### PR DESCRIPTION
By importing the target module in a new process (old way),
modules with dependencies declared in the manifest where limited.

This change imports the module only into the scope of the function,
therefore being able to import additional dependencies
and having access to and setup (importing) done in the global scope