### PR TITLE
Export new aliases from #72 in PSD1

### DIFF
--- a/BuildHelpers/BuildHelpers.psd1
+++ b/BuildHelpers/BuildHelpers.psd1
@@ -67,7 +67,17 @@ CmdletsToExport = '*'
 VariablesToExport = '*'
 
 # Aliases to export from this module
-AliasesToExport = @('Set-BuildVariable', 'Get-NextPSGalleryVersion')
+AliasesToExport = @(
+    'Set-BuildVariable'
+    'Get-NextPSGalleryVersion'
+    'Get-BuildVariables'
+    'Get-ModuleAliases'
+    'Get-ModuleFunctions'
+    'Set-ModuleAliases'
+    'Set-ModuleFormats'
+    'Set-ModuleFunctions'
+    'Set-ModuleTypes'
+)
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()


### PR DESCRIPTION
Without explicitly listing aliases for export in the PSD1, they can only be used in the module scope.

This should fix any builds broken by the release that followed #72 

/cc @lipkau @RamblingCookieMonster 