### PR TITLE
Add support for GitHub Action environment variables

### DIFF
--- a/BuildHelpers/BuildHelpers.psd1
+++ b/BuildHelpers/BuildHelpers.psd1
@@ -94,7 +94,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-         Tags = @('Continuous', 'Delivery', 'Deployment', 'Integration', 'DevOps', 'Jenkins', 'GitLab', 'CI', 'VSTS', 'AppVeyor')
+         Tags = @('Continuous', 'Delivery', 'Deployment', 'Integration', 'DevOps', 'Jenkins', 'GitLab', 'CI', 'VSTS', 'AppVeyor', 'GitHub Action')
 
         # A URL to the license for this module.
          LicenseUri = 'https://github.com/RamblingCookieMonster/BuildHelpers/blob/master/LICENSE'

--- a/BuildHelpers/Public/Get-BuildVariable.ps1
+++ b/BuildHelpers/Public/Get-BuildVariable.ps1
@@ -22,6 +22,7 @@ function Get-BuildVariable {
                 Bamboo
                 GoCD
                 Travis CI
+                GitHub Action
 
             For Teamcity the VCS Checkout Mode needs to be to checkout files on agent.
             Since TeamCity 10.0, this is the default setting for the newly created build configurations.
@@ -99,6 +100,7 @@ function Get-BuildVariable {
         'BAMBOO_BUILDKEY'       { 'Bamboo'; break }
         'GOCD_SERVER_URL'       { 'GoCD'; break }
         'TRAVIS'                { 'Travis CI'; break }
+        'GITHUB_WORKFLOW'       { 'GitHub Action'; break }
     }
     if(-not $BuildSystem)
     {
@@ -114,6 +116,7 @@ function Get-BuildVariable {
         'SYSTEM_DEFAULTWORKINGDIRECTORY' { (Get-Item -Path "ENV:$_").Value; break } # VSTS (Visual studio team services)
         'BAMBOO_BUILD_WORKING_DIRECTORY' { (Get-Item -Path "ENV:$_").Value; break } # Bamboo
         'TRAVIS_BUILD_DIR'               { (Get-Item -Path "ENV:$_").Value; break } # Travis CI
+        'GITHUB_WORKSPACE'               { (Get-Item -Path "ENV:$_").Value; break } # GitHub Action
     }
     if(-not $BuildRoot)
     {
@@ -135,6 +138,7 @@ function Get-BuildVariable {
         'BUILD_SOURCEBRANCHNAME'        { (Get-Item -Path "ENV:$_").Value; break } # VSTS
         'BAMBOO_REPOSITORY_GIT_BRANCH'  { (Get-Item -Path "ENV:$_").Value; break } # Bamboo
         'TRAVIS_BRANCH'                 { (Get-Item -Path "ENV:$_").Value; break } # Travis CI
+        'GITHUB_REF'                    { (Get-Item -Path "ENV:$_").Value.Replace('refs/heads/', ''); break } # GitHub Action
     }
     if(-not $BuildBranch)
     {
@@ -199,6 +203,14 @@ function Get-BuildVariable {
             "$env:TRAVIS_COMMIT_MESSAGE"
             break
         }
+        'GITHUB_SHA' {
+            if($WeCanGit)
+            {
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                break
+            } # GitHub Action https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables
+        }
+
     }
     if(-not $CommitMessage)
     {

--- a/Tests/TestData/dummymodule.psd1
+++ b/Tests/TestData/dummymodule.psd1
@@ -84,7 +84,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-         Tags = @('Continuous', 'Delivery', 'Deployment', 'Integration', 'DevOps', 'Jenkins', 'GitLab', 'CI', 'VSTS', 'AppVeyor')
+         Tags = @('Continuous', 'Delivery', 'Deployment', 'Integration', 'DevOps', 'Jenkins', 'GitLab', 'CI', 'VSTS', 'AppVeyor', 'GitHub Action')
 
         # A URL to the license for this module.
          LicenseUri = 'https://github.com/RamblingCookieMonster/BuildHelpers/blob/master/LICENSE'


### PR DESCRIPTION
This Fixes #96 and adds support for a portion of the environment variables exposed when running in a GitHub Action. Specifically:

```
$env:BHBuildSystem
$env:BHProjectPath
$env:BHBranchName
$env:BHCommitMessage
```

GitHub Actions don't currently have the concept of a build number since they can be invoked from a number of events against a repo that don't involve code commits. For this reason, `$env:BHBuildNumber` will take the fallback of `0`.