### PR TITLE
Fix bug in Invoke-Git

### DIFF
--- a/BuildHelpers/Public/Invoke-Git.ps1
+++ b/BuildHelpers/Public/Invoke-Git.ps1
@@ -146,7 +146,10 @@
             }
             if($stderr)
             {
-                Write-Error $stderr.trim()
+                foreach ($errLine in $stderr) 
+                {
+                    Write-Error $errLine.trim()
+                }
             }
         }
     }


### PR DESCRIPTION
Fix to prevent the following from occurring due to $stderr sometimes being an array due to lines 124-130:

2019-03-13T16:36:28.5845108Z ##[error]Write-Error : Cannot convert 'System.Object[]' to the type 'System.String' required by parameter 'Message'. Specified 
method is not supported.
At C:\Program Files\WindowsPowerShell\Modules\BuildHelpers\2.0.7\Public\Invoke-Git.ps1:149 char:29
+                 Write-Error $stderr.trim()
+                             ~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Write-Error], ParameterBindingException
    + FullyQualifiedErrorId : CannotConvertArgument,Microsoft.PowerShell.Commands.WriteErrorCommand