### PR TITLE
Update Get-BuildEnvironment.ps1

### DIFF
--- a/BuildHelpers/Public/Get-BuildEnvironment.ps1
+++ b/BuildHelpers/Public/Get-BuildEnvironment.ps1
@@ -13,6 +13,7 @@ function Get-BuildEnvironment {
             ProjectPath      via Get-BuildVariable
             BranchName       via Get-BuildVariable
             CommitMessage    via Get-BuildVariable
+            CommitHash       via Get-BuildVariable
             BuildNumber      via Get-BuildVariable
             ProjectName      via Get-ProjectName
             PSModuleManifest via Get-PSModuleManifest
@@ -100,6 +101,7 @@ function Get-BuildEnvironment {
         ProjectPath = ${Build.Vars}.ProjectPath
         BranchName  = ${Build.Vars}.BranchName
         CommitMessage = ${Build.Vars}.CommitMessage
+        CommitHash = ${Build.Vars}.CommitHash
         BuildNumber = ${Build.Vars}.BuildNumber
         ProjectName = ${Build.ProjectName}
         PSModuleManifest = ${Build.ManifestPath}


### PR DESCRIPTION
TIL

It's more than just passing a hash in Get-BuildVariable, you also have to define it in Get-BuildEnvironment.

I never looked closely at at the output that was being produced in my test pipeline to see that it wasn't including the Commit hash, but this is.
Really fixes #92 