### PR TITLE
Bh is pull request

### DIFF
--- a/BuildHelpers/Public/Get-BuildEnvironment.ps1
+++ b/BuildHelpers/Public/Get-BuildEnvironment.ps1
@@ -15,6 +15,7 @@ function Get-BuildEnvironment {
             CommitMessage    via Get-BuildVariable
             CommitHash       via Get-BuildVariable
             BuildNumber      via Get-BuildVariable
+            IsPullRequest    via Get-BuildVariable
             ProjectName      via Get-ProjectName
             PSModuleManifest via Get-PSModuleManifest
             ModulePath       via Split-Path on PSModuleManifest
@@ -106,6 +107,11 @@ function Get-BuildEnvironment {
         ProjectName = ${Build.ProjectName}
         PSModuleManifest = ${Build.ManifestPath}
         ModulePath = ${Build.ModulePath}
+    }
+    if (${Build.Vars}.IsPullRequest) {
+        #This will ensure IsPullRequest is inserted into the ordered table after the BuildNumber property
+        $index = $($BuildHelpersVariables.keys).IndexOf("BuildNumber")
+        $BuildHelpersVariables.Insert($index+1,"IsPullRequest",${Build.Vars}.IsPullRequest)
     }
     foreach($VarName in $BuildHelpersVariables.keys){
         $BuildOutput = $BuildOutput -replace "\`$$VarName", $BuildHelpersVariables[$VarName]

--- a/BuildHelpers/Public/Get-BuildVariable.ps1
+++ b/BuildHelpers/Public/Get-BuildVariable.ps1
@@ -35,6 +35,7 @@ function Get-BuildVariable {
                 BranchName: git branch for this build
                 CommitMessage: git commit message for this build
                 BuildNumber: Build number provided by the CI system
+                IsPullRequest: "True" if CI says the current build is the result of a PR, otherwise this value will not be present
 
     .PARAMETER Path
         Path to project root. Defaults to the current working path

--- a/BuildHelpers/Scripts/Set-BuildVariable.ps1
+++ b/BuildHelpers/Scripts/Set-BuildVariable.ps1
@@ -111,10 +111,14 @@ $BuildHelpersVariables = @{
     ProjectPath = ${Build.Vars}.ProjectPath
     BranchName  = ${Build.Vars}.BranchName
     CommitMessage = ${Build.Vars}.CommitMessage
+    CommitHash = ${Build.Vars}.CommitHash
     BuildNumber = ${Build.Vars}.BuildNumber
     ProjectName = ${Build.ProjectName}
     PSModuleManifest = ${Build.ManifestPath}
     ModulePath = $(Split-Path -Path ${Build.ManifestPath} -Parent)
+}
+if (${Build.Vars}.IsPullRequest) {
+    $BuildHelpersVariables.IsPullRequest = ${Build.Vars}.IsPullRequest
 }
 foreach ($VarName in $BuildHelpersVariables.Keys) {
     Set-Variable -Scope $Scope -Name ('{0}{1}' -f $VariableNamePrefix,$VarName) -Value $BuildHelpersVariables[$VarName]

--- a/BuildHelpers/Scripts/Set-BuildVariable.ps1
+++ b/BuildHelpers/Scripts/Set-BuildVariable.ps1
@@ -12,7 +12,9 @@
         BHProjectPath      via Get-BuildVariable
         BHBranchName       via Get-BuildVariable
         BHCommitMessage    via Get-BuildVariable
+        BHCommitHash       via Get-BuildVariable
         BHBuildNumber      via Get-BuildVariable
+        BHIsPullRequest    via Get-BuildVariable
         BHProjectName      via Get-ProjectName
         BHPSModuleManifest via Get-PSModuleManifest
         BHModulePath     via Split-Path on BHPSModuleManifest
@@ -118,7 +120,7 @@ $BuildHelpersVariables = @{
     ModulePath = $(Split-Path -Path ${Build.ManifestPath} -Parent)
 }
 if (${Build.Vars}.IsPullRequest) {
-    $BuildHelpersVariables.IsPullRequest = ${Build.Vars}.IsPullRequest
+    $BuildHelpersVariables.IsPullRequest = [bool]${Build.Vars}.IsPullRequest
 }
 foreach ($VarName in $BuildHelpersVariables.Keys) {
     Set-Variable -Scope $Scope -Name ('{0}{1}' -f $VariableNamePrefix,$VarName) -Value $BuildHelpersVariables[$VarName]


### PR DESCRIPTION
fixes #79 
This reads environment variables in the following CIs to set a `IsPullRequest` variable if the current build has been triggered by a PR: AppVeyor, Gitlab CI, Azure Pipelines, Bamboo, GoCD, Travis CI, and Github Actions.  I couldn't figure out a way to determine it in Jenkins or Teamcity but if there is a reliable way that someone is aware of it's easy to see in the code where to set it.

I thought about figuring out way to determine this from Git directly but I'm not sure it's possible or even reasonable.  GIt doesn't have a notion of a pull request directly it seems, in Github a pull request creates a branch something like `refs/remotes/pull/2/merge` but other systems may do something different so I'm not sure checking that the current branch matches a certain pattern is going to be reliable

If the build environment says the build was triggered by a PR, it says `IsPullRequest` to be `True` otherwise it won't create the variable, so you can then check for the existence of the environment variable (or `$BHIsPullRequest` in the case of Set-BuildVariable.ps1)

I also thought about setting some more details about the PR, like maybe the PR number, the source branch, the destination branch, etc, but I'd need help from people with experience in other CI systems to do that.  I know where to find the values in my CI, Azure Pipelines, but less so in the others.

Finally, I'd added `CommitHash` a while ago but realized I'd never added it to `Set-BuildVariable.ps1` so in addition to adding the logic for `IsPullRequest` in there I also added `CommitHash` to that file.