### PR TITLE
Removing 'path' parameter from 'git log' command

### DIFF
--- a/BuildHelpers/Public/Get-BuildVariable.ps1
+++ b/BuildHelpers/Public/Get-BuildVariable.ps1
@@ -160,21 +160,21 @@ function Get-BuildVariable {
         'CI_COMMIT_SHA' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Gitlab 9.0+ - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
         'CI_BUILD_REF' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Gitlab 8.x - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
         'GIT_COMMIT' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Jenkins - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
@@ -183,24 +183,24 @@ function Get-BuildVariable {
             break
             # Azure Pipelines Classic Build & YAML(https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables)
         }
-        'SYSTEM_DEFAULTWORKINGDIRECTORY' { #Azure Pipelines, this will be triggered in the case of a classic release pipeline
+        'BUILD_SOURCEVERSION' { #Azure Pipelines, this will be triggered in the case of a classic release pipeline
             if($WeCanGit)
             {
-                (Invoke-Git @IGParams -Arguments "log --format=%B -n 1").split([Environment]::NewLine,[System.StringSplitOptions]::RemoveEmptyEntries) -join " "
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Azure Pipelines Classic Release (https://docs.microsoft.com/en-us/azure/devops/pipelines/release/variables)
         }
         'BUILD_VCS_NUMBER' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Teamcity https://confluence.jetbrains.com/display/TCD10/Predefined+Build+Parameters
         }
         'BAMBOO_REPOSITORY_REVISION_NUMBER' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Bamboo https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html
         }
@@ -211,7 +211,7 @@ function Get-BuildVariable {
         'GITHUB_SHA' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # GitHub Actions https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables
         }

--- a/BuildHelpers/Public/Get-BuildVariable.ps1
+++ b/BuildHelpers/Public/Get-BuildVariable.ps1
@@ -160,21 +160,21 @@ function Get-BuildVariable {
         'CI_COMMIT_SHA' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
                 break
             } # Gitlab 9.0+ - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
         'CI_BUILD_REF' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
                 break
             } # Gitlab 8.x - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
         'GIT_COMMIT' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
                 break
             } # Jenkins - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
@@ -186,21 +186,21 @@ function Get-BuildVariable {
         'SYSTEM_DEFAULTWORKINGDIRECTORY' { #Azure Pipelines, this will be triggered in the case of a classic release pipeline
             if($WeCanGit)
             {
-                (Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )").split([Environment]::NewLine,[System.StringSplitOptions]::RemoveEmptyEntries) -join " "
+                (Invoke-Git @IGParams -Arguments "log --format=%B -n 1").split([Environment]::NewLine,[System.StringSplitOptions]::RemoveEmptyEntries) -join " "
                 break
             } # Azure Pipelines Classic Release (https://docs.microsoft.com/en-us/azure/devops/pipelines/release/variables)
         }
         'BUILD_VCS_NUMBER' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
                 break
             } # Teamcity https://confluence.jetbrains.com/display/TCD10/Predefined+Build+Parameters
         }
         'BAMBOO_REPOSITORY_REVISION_NUMBER' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
                 break
             } # Bamboo https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html
         }
@@ -211,7 +211,7 @@ function Get-BuildVariable {
         'GITHUB_SHA' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
                 break
             } # GitHub Actions https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables
         }


### PR DESCRIPTION
This fixes #109 and #110. 

As far as I have understood the git documentation, the path parameter for 'git log' is more like a filter to get the last commit for a specific directory or file. So here the path is it used twice and the two values may contradict each other . The current path must be set to somewhere in the git repo anyway and then - if things are as expected - the path (SYSTEM_DEFAULTWORKINGDIRECTORY) shows to the same repo again. In my case, I am having more than one artifact to deal with and the path in SYSTEM_DEFAULTWORKINGDIRECTORY does not point to the repo. The repo is in a separate folder in SYSTEM_DEFAULTWORKINGDIRECTORY.

And if the commit message could not be retrieved, we get in in line [224](https://github.com/RamblingCookieMonster/BuildHelpers/blob/8e484dc98541a957e75e4e2f8bd7f6e223dbe85d/BuildHelpers/Public/Get-BuildVariable.ps1#L224) without the path.

I don't see any value in defining the path as it is done for the 'git log' calls. Please correct me if I am wrong.
