### PR TITLE
Fix using scoop shims

### DIFF
--- a/BuildHelpers/Public/Invoke-Git.ps1
+++ b/BuildHelpers/Public/Invoke-Git.ps1
@@ -71,7 +71,7 @@
         $Split = "`n",
         $Raw,
         [validatescript({
-            if(-not (Get-Command $_ -ErrorAction SilentlyContinue))
+            if(-not (Get-Command $_ -CommandType Application -ErrorAction SilentlyContinue))
             {
                 throw "Could not find command at GitPath [$_]"
             }
@@ -84,7 +84,7 @@
     # http://stackoverflow.com/questions/8761888/powershell-capturing-standard-out-and-error-with-start-process
     $pinfo = New-Object System.Diagnostics.ProcessStartInfo
     if(!$PSBoundParameters.ContainsKey('GitPath')) {
-        $GitPath = (Get-Command $GitPath -ErrorAction Stop)[0].Path
+        $GitPath = (Get-Command $GitPath -CommandType Application -ErrorAction Stop)[0].Path
     }
     $pinfo.FileName = $GitPath
     $Command = $GitPath


### PR DESCRIPTION
Scoop uses ps1 shims to run installed applications, getting command will try to execute the script instead of the real application resulting in

```
MethodInvocationException: C:\Users\<redacted>\Documents\PowerShell\Modules\BuildHelpers\2.0.11\Public\Invoke-Git.ps1:103
Line |
 103 |      $null = $p.Start()
     |      ~~~~~~~~~~~~~~~~~~
     | Exception calling "Start" with "0" argument(s): "The specified executable is not a valid application for this OS platform."
```