### PR TITLE
fix-credentials-set-multiple-time

### DIFF
--- a/BuildHelpers/Public/Get-NextNugetPackageVersion.ps1
+++ b/BuildHelpers/Public/Get-NextNugetPackageVersion.ps1
@@ -60,7 +60,7 @@
                     $Params.add('Credential', $Credential)
                 }
                 $Existing = $null
-                $Existing = Find-NugetPackage @params -PackageSourceUrl $PackageSourceUrl -Credential $Credential -IsLatest -ErrorAction Stop
+                $Existing = Find-NugetPackage @params -PackageSourceUrl $PackageSourceUrl -IsLatest -ErrorAction Stop
             }
             Catch
             {


### PR DESCRIPTION
As credentials are set in params hashtable, it needs to be removed from cmdlet find-nugetpackage other the credential parameter is supply twice and cmdlet doesn't work.