### PR TITLE
Environment variable creation improvements

### DIFF
--- a/BuildHelpers/Public/Set-BuildEnvironment.ps1
+++ b/BuildHelpers/Public/Set-BuildEnvironment.ps1
@@ -118,7 +118,7 @@ function Set-BuildEnvironment {
     $BuildHelpersVariables = Get-BuildEnvironment @GBEParams
     foreach ($VarName in $BuildHelpersVariables.Keys) {
         if($null -ne $BuildHelpersVariables[$VarName]) {
-            $prefixedVar = "$VariableNamePrefix$VarName"
+            $prefixedVar = "$VariableNamePrefix$VarName".ToUpperInvariant()
 
             Write-Verbose "storing [$prefixedVar] with value '$($BuildHelpersVariables[$VarName])'."
             $Output = New-Item -Path Env:\ -Name $prefixedVar -Value $BuildHelpersVariables[$VarName] -Force:$Force


### PR DESCRIPTION
Typically, environment variables are UPPER-CASED, particularly on *nix-based operating systems. Even Windows defaults to UPPER-CASED environment variable names. This pull request addresses that issue and closes #138.