### PR TITLE
Allow setting of custom build variables

### DIFF
--- a/BuildHelpers/Public/Set-BuildEnvironment.ps1
+++ b/BuildHelpers/Public/Set-BuildEnvironment.ps1
@@ -118,7 +118,7 @@ function Set-BuildEnvironment {
     $BuildHelpersVariables = Get-BuildEnvironment @GBEParams
     foreach ($VarName in $BuildHelpersVariables.Keys) {
         if($null -ne $BuildHelpersVariables[$VarName]) {
-            $prefixedVar = "$VariableNamePrefix$VarName"
+            $prefixedVar = "$VariableNamePrefix$VarName".ToUpperInvariant()
 
             Write-Verbose "storing [$prefixedVar] with value '$($BuildHelpersVariables[$VarName])'."
             $Output = New-Item -Path Env:\ -Name $prefixedVar -Value $BuildHelpersVariables[$VarName] -Force:$Force


### PR DESCRIPTION
This pull request allows one to specify custom build variables that should be created when setting up the build environment when invoking `Set-BuildEnvironment`. Just like for the `-BuildOutput` parameter, it allows for the values of custom variables to contain the names of other custom variables and BuildHelpers-defined variables defined by the current call, which will be expanded.

For example, assuming my project is located in `C:\Projects\MyProject`:

```powershell
Set-BuildEnvironment `
    -VariableNamePrefix 'MYPROJECT_' `
    -BuildOutput '$ProjectPath\build' `
    -CustomVariables @{
        'ARTIFACTSDIR' = '$ProjectPath\out'
        'HELPARTIFACTSDIR' = '$ARTIFACTSDIR\docs'
    } `
```

This would result in the following output for the custom variables:

```text
Name                        Value
----                        -----
MYPROJECT_ARTIFACTSDIR      C:\Projects\MyProject\out
MYPROJECT_HELPARTIFACTSDIR  C:\Projects\MyProject\out\docs
```

Closes #141