### PR TITLE
fix: prevent git commands from hanging when using pager

### DIFF
--- a/BuildHelpers/BuildHelpers.psd1
+++ b/BuildHelpers/BuildHelpers.psd1
@@ -4,7 +4,7 @@
 RootModule = 'BuildHelpers.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.0'
+ModuleVersion = '2.0.1'
 
 # ID used to uniquely identify this module
 GUID = 'ec079170-28b7-40b4-aaae-f8ebf76850ab'
@@ -106,7 +106,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = "Add support for GitHub Actions, and fix bug in Invoke-Git error handling"
+        ReleaseNotes = "Add support for GitHub Actions, and fix bug in Invoke-Git error handling`nfix: prevent git commands from hanging when using pager"
 
     } # End of PSData hashtable
 

--- a/BuildHelpers/Public/Get-BuildVariable.ps1
+++ b/BuildHelpers/Public/Get-BuildVariable.ps1
@@ -146,7 +146,7 @@ function Get-BuildVariable {
         {
             # Using older than 1.6.3 in your build system? Yuck
             # Thanks to earl: http://stackoverflow.com/a/1418022/3067642
-            $BuildBranch = Invoke-Git @IGParams -Arguments "rev-parse --no-pager --abbrev-ref HEAD"
+            $BuildBranch = Invoke-Git @IGParams -Arguments "--no-pager rev-parse --abbrev-ref HEAD"
         }
     }
 
@@ -160,21 +160,21 @@ function Get-BuildVariable {
         'CI_COMMIT_SHA' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "--no-pager log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Gitlab 9.0+ - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
         'CI_BUILD_REF' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "--no-pager log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Gitlab 8.x - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
         'GIT_COMMIT' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "--no-pager log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Jenkins - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
@@ -186,21 +186,21 @@ function Get-BuildVariable {
         'BUILD_SOURCEVERSION' { #Azure Pipelines, this will be triggered in the case of a classic release pipeline
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "--no-pager log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Azure Pipelines Classic Release (https://docs.microsoft.com/en-us/azure/devops/pipelines/release/variables)
         }
         'BUILD_VCS_NUMBER' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "--no-pager log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Teamcity https://confluence.jetbrains.com/display/TCD10/Predefined+Build+Parameters
         }
         'BAMBOO_REPOSITORY_REVISION_NUMBER' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "--no-pager log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Bamboo https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html
         }
@@ -211,7 +211,7 @@ function Get-BuildVariable {
         'GITHUB_SHA' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "--no-pager log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # GitHub Actions https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables
         }
@@ -221,7 +221,7 @@ function Get-BuildVariable {
     {
         if($WeCanGit)
         {
-            $CommitMessage = Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1"
+            $CommitMessage = Invoke-Git @IGParams -Arguments "--no-pager log --format=%B -n 1"
         }
     }
     if($CommitMessage) {$CommitMessage = $CommitMessage -join "`n"}
@@ -243,7 +243,7 @@ function Get-BuildVariable {
     {
         if($WeCanGit)
         {
-            $CommitHash = Invoke-Git @IGParams -Arguments "log --no-pager --format=%H -n 1"
+            $CommitHash = Invoke-Git @IGParams -Arguments "--no-pager log --format=%H -n 1"
         }        
     }
     # Build number

--- a/BuildHelpers/Public/Get-BuildVariable.ps1
+++ b/BuildHelpers/Public/Get-BuildVariable.ps1
@@ -146,7 +146,7 @@ function Get-BuildVariable {
         {
             # Using older than 1.6.3 in your build system? Yuck
             # Thanks to earl: http://stackoverflow.com/a/1418022/3067642
-            $BuildBranch = Invoke-Git @IGParams -Arguments "rev-parse --abbrev-ref HEAD"
+            $BuildBranch = Invoke-Git @IGParams -Arguments "rev-parse --no-pager --abbrev-ref HEAD"
         }
     }
 
@@ -160,21 +160,21 @@ function Get-BuildVariable {
         'CI_COMMIT_SHA' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Gitlab 9.0+ - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
         'CI_BUILD_REF' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Gitlab 8.x - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
         'GIT_COMMIT' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Jenkins - thanks to mipadi http://stackoverflow.com/a/3357357/3067642
         }
@@ -186,21 +186,21 @@ function Get-BuildVariable {
         'BUILD_SOURCEVERSION' { #Azure Pipelines, this will be triggered in the case of a classic release pipeline
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Azure Pipelines Classic Release (https://docs.microsoft.com/en-us/azure/devops/pipelines/release/variables)
         }
         'BUILD_VCS_NUMBER' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Teamcity https://confluence.jetbrains.com/display/TCD10/Predefined+Build+Parameters
         }
         'BAMBOO_REPOSITORY_REVISION_NUMBER' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # Bamboo https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html
         }
@@ -211,7 +211,7 @@ function Get-BuildVariable {
         'GITHUB_SHA' {
             if($WeCanGit)
             {
-                Invoke-Git @IGParams -Arguments "log --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
+                Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1 $( (Get-Item -Path "ENV:$_").Value )"
                 break
             } # GitHub Actions https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables
         }
@@ -221,7 +221,7 @@ function Get-BuildVariable {
     {
         if($WeCanGit)
         {
-            $CommitMessage = Invoke-Git @IGParams -Arguments "log --format=%B -n 1"
+            $CommitMessage = Invoke-Git @IGParams -Arguments "log --no-pager --format=%B -n 1"
         }
     }
     if($CommitMessage) {$CommitMessage = $CommitMessage -join "`n"}
@@ -243,7 +243,7 @@ function Get-BuildVariable {
     {
         if($WeCanGit)
         {
-            $CommitHash = Invoke-Git @IGParams -Arguments "log --format=%H -n 1"
+            $CommitHash = Invoke-Git @IGParams -Arguments "log --no-pager --format=%H -n 1"
         }        
     }
     # Build number

--- a/BuildHelpers/Public/Get-GitChangedFile.ps1
+++ b/BuildHelpers/Public/Get-GitChangedFile.ps1
@@ -148,7 +148,7 @@ function Get-GitChangedFile {
     $Path = (Resolve-Path $Path).Path
     try
     {
-        $GitPathRaw = Invoke-Git rev-parse --no-pager --show-toplevel -Path $Path -ErrorAction Stop
+        $GitPathRaw = Invoke-Git --no-pager rev-parse --show-toplevel -Path $Path -ErrorAction Stop
     }
     catch
     {
@@ -197,7 +197,7 @@ function Get-GitChangedFile {
         return
     }
 
-    [string[]]$Files = Invoke-Git "diff --no-pager --name-only $revisionString" -Path $GitPath
+    [string[]]$Files = Invoke-Git "--no-pager diff --name-only $revisionString" -Path $GitPath
     if ($Files) {
         Write-Verbose "Found [$($Files.Count)] files with raw values:`n$($Files | Foreach-Object {"'$_'"} | Out-String)"
         if($Include)

--- a/BuildHelpers/Public/Get-GitChangedFile.ps1
+++ b/BuildHelpers/Public/Get-GitChangedFile.ps1
@@ -148,7 +148,7 @@ function Get-GitChangedFile {
     $Path = (Resolve-Path $Path).Path
     try
     {
-        $GitPathRaw = Invoke-Git rev-parse --show-toplevel -Path $Path -ErrorAction Stop
+        $GitPathRaw = Invoke-Git rev-parse --no-pager --show-toplevel -Path $Path -ErrorAction Stop
     }
     catch
     {
@@ -197,7 +197,7 @@ function Get-GitChangedFile {
         return
     }
 
-    [string[]]$Files = Invoke-Git "diff --name-only $revisionString" -Path $GitPath
+    [string[]]$Files = Invoke-Git "diff --no-pager --name-only $revisionString" -Path $GitPath
     if ($Files) {
         Write-Verbose "Found [$($Files.Count)] files with raw values:`n$($Files | Foreach-Object {"'$_'"} | Out-String)"
         if($Include)

--- a/BuildHelpers/Public/Get-ProjectName.ps1
+++ b/BuildHelpers/Public/Get-ProjectName.ps1
@@ -110,7 +110,7 @@ function Get-ProjectName
         #Last ditch, are you in Azure Pipelines or another CI that checks into a folder unrelated to the project?
         #let's try some git
         elseif ( $WeCanGit ) {
-            $result = (Invoke-Git -Path $Path -GitPath $GitPath -Arguments "remote --no-pager get-url origin").Split('/')[-1] -replace "\.git",""
+            $result = (Invoke-Git -Path $Path -GitPath $GitPath -Arguments "--no-pager remote get-url origin").Split('/')[-1] -replace "\.git",""
         }
         else
         {

--- a/BuildHelpers/Public/Get-ProjectName.ps1
+++ b/BuildHelpers/Public/Get-ProjectName.ps1
@@ -110,7 +110,7 @@ function Get-ProjectName
         #Last ditch, are you in Azure Pipelines or another CI that checks into a folder unrelated to the project?
         #let's try some git
         elseif ( $WeCanGit ) {
-            $result = (Invoke-Git -Path $Path -GitPath $GitPath -Arguments "remote get-url origin").Split('/')[-1] -replace "\.git",""
+            $result = (Invoke-Git -Path $Path -GitPath $GitPath -Arguments "remote --no-pager get-url origin").Split('/')[-1] -replace "\.git",""
         }
         else
         {


### PR DESCRIPTION
- Add --no-pager flag to all git commands to prevent hanging
- Update module version to 2.0.1
- Update release notes

This fixes an issue where git commands could hang when output is piped to a pager. I ran into this issue when dealing with a commit that had a description long enough to use paging.